### PR TITLE
Do not sudo when calling virt-clone

### DIFF
--- a/virtpwn/core.py
+++ b/virtpwn/core.py
@@ -242,7 +242,7 @@ class MachinePwnManager(object):
         log.verbose("Creating new %s VM.")
         self._generate_id()
         log.debug("New VM ID: %s" % self.vm_id)
-        cmdstr = 'sudo virt-clone -o "%s" -n "%s" --auto-clone' % \
+        cmdstr = 'virt-clone -o "%s" -n "%s" --auto-clone' % \
                  (self.base, self.vm_id)
         cmd.run_or_die(cmdstr, stdout=True)
         self._save_data()


### PR DESCRIPTION
For the sake of consistency with calling other virt\* commands.

Signed-off-by: Martin Milata mmilata@srck.net
